### PR TITLE
Errors/calculate wrong total assets

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -347,8 +347,9 @@ function render10NFTs(el) {
 function renderNFTwallet() {
   // get NFT wallet El
   var nftWalletEl = walletEl.lastElementChild.lastElementChild;
-  // console.log(walletEl);
-  // console.log(nftWalletEl);
+  
+  // reset total assets to recalculate it.
+  nftTotalAssets = 0;
 
   // reset HTML Element
   nftWalletEl.innerHTML = "";

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -14,7 +14,7 @@ const walletEl = document.getElementById("wallet");
 const nft1 = document.getElementById("nft-1");
 const nft2 = document.getElementById("nft-2");
 const nft3 = document.getElementById("nft-3");
-const totalNFTsAssets = document.getElementById("total-nfts");
+const totalNFTsAssetsEl = document.getElementById("total-nfts");
 
 
 // Global variables
@@ -207,9 +207,9 @@ function renderPrice(el, collection, id) {
     if (typeof data.price != "undefined") {
       el.textContent = data.price.value/Math.pow(10, data.price.decimals) + " " + data.price.currency; // Render price
       
-      if (totalNFTsAssets) {
+      if (totalNFTsAssetsEl) {
         nftTotalAssets = nftTotalAssets + data.price.value/Math.pow(10, data.price.decimals);
-        totalNFTsAssets.textContent = nftTotalAssets + " " + data.price.currency;        
+        totalNFTsAssetsEl.textContent = nftTotalAssets + " " + data.price.currency;        
       };
       
     } else {

--- a/assets/js/wallet.js
+++ b/assets/js/wallet.js
@@ -12,8 +12,7 @@ nftWalletEl.addEventListener('click', function (event) {
     // console.log(contract);
 
     wallet.removeNFT(contract, identifier);
-    // reset total assets to recalculate it.
-    nftTotalAssets = 0;
+    
     renderNFTwallet();
   }
 });

--- a/assets/js/wallet.js
+++ b/assets/js/wallet.js
@@ -1,7 +1,7 @@
 var nftWalletEl = walletEl.lastElementChild.lastElementChild;
 
 //
-// catch click on nftWallet
+// catch click on remove button on nftWallet page
 nftWalletEl.addEventListener('click', function (event) {
   var element = event.target;
   // console.log(element);
@@ -12,7 +12,8 @@ nftWalletEl.addEventListener('click', function (event) {
     // console.log(contract);
 
     wallet.removeNFT(contract, identifier);
-    
+    // reset total assets to recalculate it.
+    nftTotalAssets = 0;
     renderNFTwallet();
   }
 });


### PR DESCRIPTION
Problem: nftTotalAssets  keeps adding up when user click on remove NFT from wallet button.

Solution: nftTotalAssets should be reset to 0 before render wallet page.